### PR TITLE
Bug fix: Endpoint parameter is incorrect

### DIFF
--- a/bing-docs/bing-web-search/quickstarts/sdk/web-search-client-library-python.md
+++ b/bing-docs/bing-web-search/quickstarts/sdk/web-search-client-library-python.md
@@ -95,8 +95,14 @@ If the response contains web pages, images, news, or videos, the first result fo
     # Replace with your subscription key.
     subscription_key = "YOUR_SUBSCRIPTION_KEY"
 
-    # Instantiate the client and replace with your endpoint.
-    client = WebSearchClient(endpoint="YOUR_ENDPOINT", credentials=CognitiveServicesCredentials(subscription_key))
+    # Instantiate the client and replace with the required endpoint.
+    '''
+    https://api.bing.microsoft.com/v7.0/search	- Web Search
+    https://api.bing.microsoft.com/v7.0/suggestions/search - Autosuggest
+    https://api.bing.microsoft.com/v7.0/images/search - Image Search
+    https://api.bing.microsoft.com/v7.0/videos/search - Video Search
+    '''
+    client = WebSearchClient(endpoint="ENDPOINT", credentials=CognitiveServicesCredentials(subscription_key))
 
     # Make a request. Replace Yosemite if you'd like.
     web_data = client.web.search(query="Yosemite")


### PR DESCRIPTION
Documentation asks user to replace the endpoint parameter mentioned with the one specified in Azure portal("https://api.bing.microsoft.com") . This is incorrect as during runtime, an exception is thrown. "404 Client Error: Resource Not Found for url: https://api.bing.microsoft.com/?q=Microsoft+Bing+Search+Services&textDecorations=True&textFormat=HTML" Instead either one of the following endpoints should be used for the code to run as expected.
    https://api.bing.microsoft.com/v7.0/search	-  For Web Search
    https://api.bing.microsoft.com/v7.0/suggestions/search - For Autosuggest
    https://api.bing.microsoft.com/v7.0/images/search - For Image Search
    https://api.bing.microsoft.com/v7.0/videos/search - For Video Search